### PR TITLE
Fix for syntax error in compiled SQL from sfdc_formula_view_sql macro…

### DIFF
--- a/macros/sfdc_formula_view_sql.sql
+++ b/macros/sfdc_formula_view_sql.sql
@@ -12,14 +12,14 @@
             --The select statement must explicitly query from and join from the source, not the target. The replace filters point the query to the source.
             {% if ' from ' in v %}
                 {%- set v = v | replace(' from ',' from ' + source(source_name,'fivetran_formula') | string ) -%}
-                {% if target.type == 'bigquery' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
+                {% if target.type == 'bigquery' or target.type == 'databricks' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
                 {% elif target.type == 'redshift' %} {%- set v = v | replace('"fivetran_formula"', '') -%} 
                 {% else %} {%- set v = v | replace('fivetran_formula','') -%} {% endif %}
             {% endif %}
 
             {% if ' left join ' in v %}
                 {%- set v = v | replace(' left join ',' left join ' + source(source_name,'fivetran_formula') | string ) -%}
-                {% if target.type == 'bigquery' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
+                {% if target.type == 'bigquery' or target.type == 'databricks' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
                 {% elif target.type == 'redshift' %} {%- set v = v | replace('"fivetran_formula"', '') -%} 
                 {% else %} {%- set v = v | replace('fivetran_formula','') -%} {% endif %}
             {% endif %}


### PR DESCRIPTION
Fixes syntax issue in the compiled SQL from the sfdc_formula_view_sql macro when using Databricks.

When using the package with Databricks, the sfdc_formula_view_sql macro now uses the same replace filter for `fivetran_formula` as BigQuery, since the backtick syntax returned from the source() function is the same.